### PR TITLE
Styling for the Results Page

### DIFF
--- a/client/src/app/components/results/next-steps.js
+++ b/client/src/app/components/results/next-steps.js
@@ -3,18 +3,18 @@ import React from "react";
 
 const NextSteps = () => {
     return (
-        <Box sx={{ position: "relative", widht: "100%", maxWidth: 1123, height: 212}}>
+        <Box sx={{ paddingTop: 0, position: "relative", width: "100%", maxWidth: 1123, height: 0}}>
             <Typography
                 variant="h2"
                 component="div"
                 sx={{
-                    position: "absolute",
+                    position: "relative",
                     top: 0,
                     left: 0,
                     fontFamily: "Spartan-SemiBold, Helvetica",
-                    fontWeight: "bold",
+                    fontWeight: 500,
                     color: "black",
-                    lineHeight: "45px",
+                    fontSize: "30px",
                 }}
             >
                 Next Steps:
@@ -24,8 +24,8 @@ const NextSteps = () => {
                 variant="body1"
                 component="p"
                 sx={{
-                    position: "absolute",
-                    top: 61, 
+                    position: "relative",
+                    top: 0, 
                     left: 0, 
                     fontFamily: "Spartan-Regular, Helvetica",
                     color: "black",

--- a/client/src/app/components/results/next-steps.js
+++ b/client/src/app/components/results/next-steps.js
@@ -1,0 +1,41 @@
+import { Box, Typography } from "@mui/material";
+import React from "react";
+
+const NextSteps = () => {
+    return (
+        <Box sx={{ position: "relative", widht: "100%", maxWidth: 1123, height: 212}}>
+            <Typography
+                variant="h2"
+                component="div"
+                sx={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    fontFamily: "Spartan-SemiBold, Helvetica",
+                    fontWeight: "bold",
+                    color: "black",
+                    lineHeight: "45px",
+                }}
+            >
+                Next Steps:
+            </Typography>
+
+            <Typography
+                variant="body1"
+                component="p"
+                sx={{
+                    position: "absolute",
+                    top: 61, 
+                    left: 0, 
+                    fontFamily: "Spartan-Regular, Helvetica",
+                    color: "black",
+                    lineHeight: "30px",
+                }}
+            >
+                Some text here, varies on result. 
+            </Typography>
+        </Box>
+    );
+};
+
+export default NextSteps;

--- a/client/src/app/components/results/result.js
+++ b/client/src/app/components/results/result.js
@@ -1,7 +1,7 @@
 import { Box, Typography } from "@mui/material";
 import React from "react";
 
-const Results = () => {
+const Result = () => {
     return (
         <Box position="relative" width={352} height={75}>
             <Typography
@@ -14,7 +14,7 @@ const Results = () => {
                     WebkitTextStroke: "1px #3d70ec", 
                     fontFamily: "'Spartan', Helvetica", 
                     fontWeight: "bold", 
-                    color: "3d70ec",
+                    color: "#3d70ec",
                     fontSize: 40, 
                     letterSpacing: 0.15, 
                     lineHeight: "60px", 
@@ -27,4 +27,4 @@ const Results = () => {
     );
 };
 
-export default Results;
+export default Result;

--- a/client/src/app/components/results/result.js
+++ b/client/src/app/components/results/result.js
@@ -17,7 +17,7 @@ const Result = () => {
                     color: "#3d70ec",
                     fontSize: 40, 
                     letterSpacing: 0.15, 
-                    lineHeight: "60px", 
+                    lineHeight: "30px", 
                     whiteSpace: "nowrap",
                 }}
             >

--- a/client/src/app/components/results/result.js
+++ b/client/src/app/components/results/result.js
@@ -1,0 +1,30 @@
+import { Box, Typography } from "@mui/material";
+import React from "react";
+
+const Results = () => {
+    return (
+        <Box position="relative" width={352} height={75}>
+            <Typography
+                variant="h1"
+                sx={{
+                    position: "absolute", 
+                    width: 214, 
+                    top: 6, 
+                    left: -1, 
+                    WebkitTextStroke: "1px #3d70ec", 
+                    fontFamily: "'Spartan', Helvetica", 
+                    fontWeight: "bold", 
+                    color: "3d70ec",
+                    fontSize: 40, 
+                    letterSpacing: 0.15, 
+                    lineHeight: "60px", 
+                    whiteSpace: "nowrap",
+                }}
+            >
+                COVID-19
+            </Typography>
+        </Box>
+    );
+};
+
+export default Results;

--- a/client/src/app/components/results/spectrogram.js
+++ b/client/src/app/components/results/spectrogram.js
@@ -1,0 +1,17 @@
+import { Box } from "@mui/material";
+import React from "react";
+
+const Spectrogram = () => {
+    return (
+        <Box sx = {{width: 479, height: 389, position: "relative"}}>
+            <Box
+                component="img" 
+                sx={{ width: 479, height: 389, position: "absolute"}} 
+                    alt="Image" 
+                    src="https://via.placeholder.com/479x389"
+                />
+        </Box>
+    )
+}
+
+export default Spectrogram;

--- a/client/src/app/components/results/spectrogram.js
+++ b/client/src/app/components/results/spectrogram.js
@@ -6,7 +6,7 @@ const Spectrogram = () => {
         <Box sx = {{width: 479, height: 389, position: "relative"}}>
             <Box
                 component="img" 
-                sx={{ width: 479, height: 389, position: "absolute", backgroundColor: "black"}} 
+                sx={{width: 479, height: 300, position: "absolute", backgroundColor: "black"}} 
                 />
         </Box>
     )

--- a/client/src/app/components/results/spectrogram.js
+++ b/client/src/app/components/results/spectrogram.js
@@ -6,9 +6,7 @@ const Spectrogram = () => {
         <Box sx = {{width: 479, height: 389, position: "relative"}}>
             <Box
                 component="img" 
-                sx={{ width: 479, height: 389, position: "absolute"}} 
-                    alt="Image" 
-                    src="https://via.placeholder.com/479x389"
+                sx={{ width: 479, height: 389, position: "absolute", backgroundColor: "black"}} 
                 />
         </Box>
     )

--- a/client/src/app/components/results/text-header.js
+++ b/client/src/app/components/results/text-header.js
@@ -1,0 +1,24 @@
+import { Box, Typography } from "@mui/material";
+import React from "react";
+
+const Label = () => {
+  return (
+    <Box sx={{ width: 616, height: 120 }}>
+      <Typography
+        variant="h1"
+        sx={{
+          fontFamily: "'Spartan', sans-serif",
+          fontWeight: 600,
+          color: "black",
+          fontSize: 40,
+          letterSpacing: 0.15,
+          lineHeight: "60px",
+        }}
+      >
+        RespiraCheck has detected a potential for:
+      </Typography>
+    </Box>
+  );
+};
+
+export default Label;

--- a/client/src/app/components/results/text-header.js
+++ b/client/src/app/components/results/text-header.js
@@ -1,14 +1,15 @@
 import { Box, Typography } from "@mui/material";
 import React from "react";
 
-const Label = () => {
+const TextHeader = () => {
   return (
     <Box sx={{ width: 616, height: 120 }}>
       <Typography
         variant="h1"
         sx={{
           fontFamily: "'Spartan', sans-serif",
-          fontWeight: 600,
+          fontWeight: 300,
+          WebkitTextStroke: "0.5px black", 
           color: "black",
           fontSize: 40,
           letterSpacing: 0.15,
@@ -21,4 +22,4 @@ const Label = () => {
   );
 };
 
-export default Label;
+export default TextHeader;

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -17,7 +17,7 @@
 @layer base {
   html, body {
     color: var(--foreground);
-    background: #F1F7FF;
+    background: #FFFFFF;
     font-family: 'Spartan', sans-serif;
   }
 }

--- a/client/src/app/pages/home/page.js
+++ b/client/src/app/pages/home/page.js
@@ -1,12 +1,17 @@
 import React from 'react';
 
 import Navbar from '../../components/navbar';
+import Link from 'next/link';
+
 
 const Home = () => {
   return (
     <div>
       <Navbar></Navbar>
       <h1>Welcome to the Home Page</h1>
+      <Link href="/pages/results"> 
+        <span style={{ textDecoration: "underline"}}>Results</span>
+      </Link>
     </div>
   );
 };

--- a/client/src/app/pages/results/page.js
+++ b/client/src/app/pages/results/page.js
@@ -3,7 +3,7 @@ import Spectrogram from '@/app/components/results/spectrogram';
 import NextSteps from '@/app/components/results/next-steps';
 import TextHeader from '@/app/components/results/text-header';
 import Result from '@/app/components/results/result';
-import { Box, Stack, Typography } from "@mui/material";
+import { Box, Stack, ThemeProvider, Typography } from "@mui/material";
 
 import Navbar from '../../components/navbar';
 
@@ -11,24 +11,28 @@ const Results = () => {
     return (
         <div>
             <Navbar></Navbar>
-            <Stack direction="row" spacing={15} sx={{padding:"120px"}}>
-                <Spectrogram/>
-                <Stack direction="column" spacing={2}>
-                    <TextHeader/>
-                    <Result/>
-                    <Typography 
-                        sx={{
-                            position: "relative", 
-                            fontFamily: "'Spartan-Regular', Helvetica", 
-                            color: "#303030", 
-                            fontSize: "1.125rem",
-                            textDecoration: "underline"
-                        }
-                    }>
-                    Learn more about our model &gt;
-                    </Typography>
+            <Stack direction="column" spacing={0} sx={{paddingLeft: "120px", paddingTop: "80px"}}>
+                <Stack direction="row" spacing={12}>
+                    <Spectrogram/>
+                    
+                    <Stack direction="column" spacing={2}>
+                        <TextHeader/>
+                        <Result/>
+                        <Typography 
+                            sx={{
+                                position: "relative", 
+                                fontFamily: "'Spartan-Regular', Helvetica", 
+                                color: "#303030", 
+                                fontSize: "1.5rem",
+                                textDecoration: "underline"
+                            }
+                        }>
+                        Learn more about our model &gt;
+                        </Typography>
+                    </Stack>
                 </Stack>
-
+                <Box sx={{ marginTop: "-50px !important"}}><NextSteps sx={{ marginTop: "0px !important"}}/></Box>
+                
             </Stack>
             
         </div>

--- a/client/src/app/pages/results/page.js
+++ b/client/src/app/pages/results/page.js
@@ -1,4 +1,9 @@
 import React from 'react';
+import Spectrogram from '@/app/components/results/spectrogram';
+import NextSteps from '@/app/components/results/next-steps';
+import TextHeader from '@/app/components/results/text-header';
+import Result from '@/app/components/results/result';
+import { Box, Stack, Typography } from "@mui/material";
 
 import Navbar from '../../components/navbar';
 
@@ -6,8 +11,27 @@ const Results = () => {
     return (
         <div>
             <Navbar></Navbar>
-            <h1>Results page</h1>
+            <Stack direction="row" spacing={15} sx={{padding:"120px"}}>
+                <Spectrogram/>
+                <Stack direction="column" spacing={2}>
+                    <TextHeader/>
+                    <Result/>
+                    <Typography 
+                        sx={{
+                            position: "relative", 
+                            fontFamily: "'Spartan-Regular', Helvetica", 
+                            color: "#303030", 
+                            fontSize: "1.125rem",
+                            textDecoration: "underline"
+                        }
+                    }>
+                    Learn more about our model &gt;
+                    </Typography>
+                </Stack>
+
+            </Stack>
+            
         </div>
     );
 };
-export default Info;
+export default Results;


### PR DESCRIPTION
Styling for the Results Page has been completed. To access this temporarily, visit Home and Click the Results link. 

Currently there is a dummy image in place of the spectrogram. Depending on the dimensions of an average cough audio, I'm planning on implementing a scroll feature to horizontally 'scroll' through the image. (This can be implemented on this pull request, so just let me know if spectrogram images will be longer than the length allotted for the image currently!)

Here is the Preview:
<img width="1440" alt="Screenshot 2025-02-20 at 9 22 24 PM" src="https://github.com/user-attachments/assets/12a21ff1-6cd0-447d-80a8-d7aa39d7cafc" />
