### PR TITLE
Changed normalization to apply ImageNet normalization.

### DIFF
--- a/ml/data_processing/data_pipeline.py
+++ b/ml/data_processing/data_pipeline.py
@@ -95,6 +95,7 @@ class DataPipeline:
         transform = transforms.Compose([
             transforms.Resize((224, 224)),  # Resize to ResNet18 input size
             transforms.ToTensor(),  # Convert image to tensor
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),  # Normalize as per ResNet18
         ])
 
         image = Image.open(image_path).convert("RGB") # Convert from RGBA to RGB

--- a/ml/data_processing/spectrogram_processor.py
+++ b/ml/data_processing/spectrogram_processor.py
@@ -163,9 +163,12 @@ class SpectrogramProcessor(ImageProcessor):
         Returns:
             np.ndarray: The normalized spectrogram.
         """
-        spectrogram_norm = (spectrogram - spectrogram.min()) / (spectrogram.max() - spectrogram.min())
+        # spectrogram_norm = (spectrogram - spectrogram.min()) / (spectrogram.max() - spectrogram.min())
+        
+        # CURRENTLY SKIPPING THIS FUNCTION TO TEST USING TRANSFORMS WITHIN TENSOR TO 
+        # ADHERE TO IMAGE NET TRAINING SPECS
 
-        return spectrogram_norm
+        return spectrogram
 
 
     def apply_stft(self, audio_clip: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
Made our previous normalize_spectrogram function pass straight through, and instead am now normalizing when we load the tensors. This way we are normalizing the images to the same std and mean as ImageNet (what ResNet18 was trained on).